### PR TITLE
Fix relative import with no know parent package

### DIFF
--- a/kicad_pcb.py
+++ b/kicad_pcb.py
@@ -8,7 +8,7 @@ it is to implement a parser in an almost declarative way.
 A usage demonstration is available in `test.py`
 '''
 
-from .sexp_parser import *
+from sexp_parser.sexp_parser import *
 
 __author__ = "Zheng, Lei"
 __copyright__ = "Copyright 2016, Zheng, Lei"

--- a/kicad_pcb.py
+++ b/kicad_pcb.py
@@ -8,7 +8,10 @@ it is to implement a parser in an almost declarative way.
 A usage demonstration is available in `test.py`
 '''
 
-from sexp_parser.sexp_parser import *
+try:
+    from .sexp_parser import *
+except ImportError:
+    from sexp_parser.sexp_parser import *
 
 __author__ = "Zheng, Lei"
 __copyright__ = "Copyright 2016, Zheng, Lei"

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import sys
 import argparse
 
 parser = argparse.ArgumentParser()
-parser.add_argument("filename",nargs='?')
+parser.add_argument("filename", nargs='?', default='test.kicad_pcb', help='If not used, the default is test.kicad_pcb')
 parser.add_argument("-l", "--log", dest="logLevel",
     choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
     help="Set the logging level")
@@ -16,7 +16,7 @@ args = parser.parse_args()
 logging.basicConfig(level=args.logLevel,
         format="%(filename)s:%(lineno)s: %(levelname)s - %(message)s")
 
-pcb = KicadPCB.load('test.kicad_pcb' if args.filename is None else args.filename)
+pcb = KicadPCB.load(args.filename)
 
 # check for error
 for e in pcb.getError():

--- a/test.py
+++ b/test.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 
 from kicad_pcb import *
-
-try:
-    from .sexp_parser import *
-except ImportError:
-    from sexp_parser.sexp_parser import *
+from sexp_parser import *
 
 import sys
 import argparse

--- a/test.py
+++ b/test.py
@@ -16,7 +16,7 @@ args = parser.parse_args()
 logging.basicConfig(level=args.logLevel,
         format="%(filename)s:%(lineno)s: %(levelname)s - %(message)s")
 
-pcb = KicadPCB.load('test.kicad_pcb' if args.filename is None else args.filename[0])
+pcb = KicadPCB.load('test.kicad_pcb' if args.filename is None else args.filename)
 
 # check for error
 for e in pcb.getError():

--- a/test.py
+++ b/test.py
@@ -2,16 +2,17 @@
 
 from kicad_pcb import *
 from sexp_parser import *
+
 import sys
 import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("filename",nargs='?')
-parser.add_argument("-l", "--log", dest="logLevel", 
-    choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], 
+parser.add_argument("-l", "--log", dest="logLevel",
+    choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
     help="Set the logging level")
 parser.add_argument("-o", "--output", help="output filename")
-args = parser.parse_args()    
+args = parser.parse_args()
 logging.basicConfig(level=args.logLevel,
         format="%(filename)s:%(lineno)s: %(levelname)s - %(message)s")
 
@@ -60,7 +61,7 @@ print('\nmodule[0] keys: {}'.format(pcb.module[0]))
 # first element of each S-Expression to be the line number
 #
 # The assignment '=' here will not overwrite existing models, but will be
-# appended to a SexpList. 
+# appended to a SexpList.
 pcb.module[0].model = SexpParser([0,'model','new/model2',
                             [0, 'at', [0, 'xyz', 0, 1, 2]],
                             [0, 'scale', [0, 'xyz', 0,2,3]],
@@ -69,9 +70,9 @@ pcb.module[0].model = SexpParser([0,'model','new/model2',
 # Or, use parseSexp() to convert S-Expression in plain text to list-based
 # representation
 pcb.module[0].model = SexpParser(parseSexp(
-    '''(model new/model3 
-        (at (xyz 1 2 3)) 
-        (scale (xyz 3 5 6)) 
+    '''(model new/model3
+        (at (xyz 1 2 3))
+        (scale (xyz 3 5 6))
         (rotate (xyz 7.0 8.0 9.0)))
     '''))
 

--- a/test.py
+++ b/test.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
 from kicad_pcb import *
-from sexp_parser import *
+
+try:
+    from .sexp_parser import *
+except ImportError:
+    from sexp_parser.sexp_parser import *
 
 import sys
 import argparse


### PR DESCRIPTION
Hey @realthunder, the `test.py` was not working for me due to the following issue.

```
Traceback (most recent call last):
  File "./kicad_parser/./test.py", line 3, in <module>
    from kicad_pcb import *
  File "./kicad_parser/kicad_pcb.py", line 11, in <module>
    from .sexp_parser import *
ImportError: attempted relative import with no known parent package
```
